### PR TITLE
chore: update CODEOWNERS for dependency files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,6 @@
 * @kinde-starter-kits/giants-kinde
 
+package-lock.json @kinde-starter-kits/sdk-engineers
+**/package-lock.json @kinde-starter-kits/sdk-engineers
+package.json @kinde-starter-kits/sdk-engineers
+**/package.json @kinde-starter-kits/sdk-engineers


### PR DESCRIPTION
Automated update to CODEOWNERS so that @kinde-oss/sdk-engineers own dependency definition files and can approve dependency PRs.